### PR TITLE
Remove mmdeploy build steps from push and pr validation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,27 +28,6 @@ clone:
   depth: 1
 
 steps:
-  - name: Build latest LS_mmdeploy docker image
-    image: plugins/docker:20.14
-    environment:
-      DOCKER_BUILDKIT: 1
-    settings: 
-      dockerfile: deploy_docker/Dockerfile
-      context: deploy_docker/
-      registry: quay.io
-      repo: quay.io/logivations/ml_all
-      privileged: true
-      build_args:
-        - BUILDKIT_INLINE_CACHE=1
-      cache_from: quay.io/logivations/ml_all:LS_mmdeploy_latest
-      tags:
-        - LS_mmdeploy_latest
-        - LS_mmdeploy_latest_${DRONE_COMMIT_SHA}
-      username:
-        from_secret: DOCKER_QUAY_USERNAME
-      password:
-        from_secret: DOCKER_QUAY_PASSWORD
-
   - name: Build latest LS_mmseg docker image
     image: plugins/docker:20.14
     environment:
@@ -99,29 +78,6 @@ clone:
   depth: 50
 
 steps:
-  - name: Build LS_mmdeploy docker image for pull request
-    image: plugins/docker:20.14
-    environment:
-      DOCKER_BUILDKIT: 1
-    settings: 
-      dockerfile: deploy_docker/Dockerfile
-      context: deploy_docker/
-      registry: quay.io
-      repo: quay.io/logivations/ml_all
-      privileged: true
-      build_args:
-        - BUILDKIT_INLINE_CACHE=1
-      cache_from: 
-        - quay.io/logivations/ml_all:LS_mmdeploy_latest
-        - quay.io/logivations/ml_all:LS_mmdeploy_pr${DRONE_PULL_REQUEST}
-      tags:
-        - LS_mmdeploy_pr${DRONE_PULL_REQUEST}
-        - LS_mmdeploy_pr${DRONE_PULL_REQUEST}_${DRONE_COMMIT_SHA}
-      username:
-        from_secret: DOCKER_QUAY_USERNAME
-      password:
-        from_secret: DOCKER_QUAY_PASSWORD
-
   - name: Build LS_mmseg docker image for pull request
     image: plugins/docker:20.14
     environment:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
As we have mmdeploy so we made a decision to remove mmdeploy builds` steps from mmsegmentation in drone.yml file

## Modification

Remove build steps  push and pr validation processes in drone.yml file

## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
