### PR TITLE
Add build mmdeploy image to mmsegmentation repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,27 @@ steps:
       password:
         from_secret: DOCKER_QUAY_PASSWORD
 
+  - name: Build LS_mmdeploy docker image for pull request
+    image: plugins/docker:20.14
+    environment:
+      DOCKER_BUILDKIT: 1
+    settings:
+      dockerfile: docker/MMDeploy.Dockerfile
+      context: docker/
+      registry: quay.io
+      repo: quay.io/logivations/ml_all
+      privileged: true
+      build_args: 
+        - BUILDKIT_INLINE_CACHE=1
+      cache_from: quay.io/logivations/ml_all:LS_mmdeploy_latest
+      tags:
+        - LS_mmdeploy_latest
+        - LS_mmdeploy_latest_${DRONE_COMMIT_SHA}
+      username:
+        from_secret: DOCKER_QUAY_USERNAME
+      password:
+        from_secret: DOCKER_QUAY_PASSWORD
+
 #######################################################################################################################
 #######################################################################################################################
 #######################################################################################################################

--- a/.drone.yml
+++ b/.drone.yml
@@ -102,3 +102,26 @@ steps:
         from_secret: DOCKER_QUAY_USERNAME
       password:
         from_secret: DOCKER_QUAY_PASSWORD
+
+  - name: Build LS_mmdeploy docker image for pull request
+    image: plugins/docker:20.14
+    environment:
+      DOCKER_BUILDKIT: 1
+    settings:
+      dockerfile: docker/MMDeploy.Dockerfile
+      context: docker/
+      registry: quay.io
+      repo: quay.io/logivations/ml_all
+      privileged: true
+      build_args: 
+        - BUILDKIT_INLINE_CACHE=1
+      cache_from:
+        - quay.io/logivations/ml_all:LS_mmdeploy_pr${DRONE_PULL_REQUEST}
+        - quay.io/logivations/ml_all:LS_mmdeploy_latest
+      tags:
+        - LS_mmdeploy_pr${DRONE_PULL_REQUEST}
+        - LS_mmdeploy_pr${DRONE_PULL_REQUEST}_${DRONE_COMMIT_SHA}
+      username:
+        from_secret: DOCKER_QUAY_USERNAME
+      password:
+        from_secret: DOCKER_QUAY_PASSWORD

--- a/docker/MMDeploy.Dockerfile
+++ b/docker/MMDeploy.Dockerfile
@@ -1,0 +1,22 @@
+FROM openmmlab/mmdeploy:ubuntu20.04-cuda11.8-mmdeploy1.3.0
+
+#MMSegmentation
+#COPY ./ /root/workspace/mmsegmentation/
+#ENV FORCE_CUDA="1"
+#RUN pip install -r /root/workspace/mmsegmentation/requirements.txt
+#RUN pip install --no-cache-dir -e /root/workspace/mmsegmentation
+
+# previous method of local installation fails so fallback to the official method
+RUN rm -rf /root/workspace/mmdeploy
+RUN git clone https://github.com/logivations/mmdeploy.git /root/workspace/mmdeploy
+
+# RUN mim install mmsegmentation
+RUN python3 -m pip install ftfy regex
+
+RUN pip install -U openmim
+
+RUN mim install git+https://github.com/logivations/mmsegmentation.git
+
+#MMPretrain
+RUN mim install git+https://github.com/logivations/mmpretrain.git
+# RUN git clone https://github.com/logivations/mmpretrain.git /code/mmpretrain


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column      |
| --------------------- | -------------------------------- |
| Platform tested on    | LabelStudio  |
| Ticket                |     [RTDT-1920](https://lvserv01.logivations.com/browse/RTDT-1920)              |

### Description of contribution

Reason for change:

We found out that mmdeploy repo depends on mmsegmentation and mmpretrain repositories. For this reason, we need to add build LS_mmdeploy image in these repos

Changes in this PR:
- Added MMDeploy.Dockerfile to docker directory 
- Added build LS_mmdeploy image to drone.yml for mmsegmentation