### PR TITLE
update CUDA to 12.8 & add export script to remove mmdeploy from dependecies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,28 +50,6 @@ steps:
       password:
         from_secret: DOCKER_QUAY_PASSWORD
 
-  - name: Build LS_mmdeploy docker image for pull request
-    image: plugins/docker:20.14
-    environment:
-      DOCKER_BUILDKIT: 1
-    settings:
-      dockerfile: docker/MMDeploy.Dockerfile
-      context: docker/
-      registry: quay.io
-      repo: quay.io/logivations/ml_all
-      privileged: true
-      build_args: 
-        - BUILDKIT_INLINE_CACHE=1
-        - GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKKEN_SEGMENTATION}
-      cache_from: quay.io/logivations/ml_all:LS_mmdeploy_latest
-      tags:
-        - LS_mmdeploy_latest
-        - LS_mmdeploy_latest_${DRONE_COMMIT_SHA}
-      username:
-        from_secret: DOCKER_QUAY_USERNAME
-      password:
-        from_secret: DOCKER_QUAY_PASSWORD
-
 #######################################################################################################################
 #######################################################################################################################
 #######################################################################################################################
@@ -121,30 +99,6 @@ steps:
       tags:
         - LS_mmseg_pr${DRONE_PULL_REQUEST}
         - LS_mmseg_pr${DRONE_PULL_REQUEST}_${DRONE_COMMIT_SHA}
-      username:
-        from_secret: DOCKER_QUAY_USERNAME
-      password:
-        from_secret: DOCKER_QUAY_PASSWORD
-
-  - name: Build LS_mmdeploy docker image for pull request
-    image: plugins/docker:20.14
-    environment:
-      DOCKER_BUILDKIT: 1
-    settings:
-      dockerfile: docker/MMDeploy.Dockerfile
-      context: docker/
-      registry: quay.io
-      repo: quay.io/logivations/ml_all
-      privileged: true
-      build_args: 
-        - BUILDKIT_INLINE_CACHE=1
-        - GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKKEN_SEGMENTATION}
-      cache_from:
-        - quay.io/logivations/ml_all:LS_mmdeploy_pr${DRONE_PULL_REQUEST}
-        - quay.io/logivations/ml_all:LS_mmdeploy_latest
-      tags:
-        - LS_mmdeploy_pr${DRONE_PULL_REQUEST}
-        - LS_mmdeploy_pr${DRONE_PULL_REQUEST}_${DRONE_COMMIT_SHA}
       username:
         from_secret: DOCKER_QUAY_USERNAME
       password:

--- a/auto_training/export_model.py
+++ b/auto_training/export_model.py
@@ -1,0 +1,176 @@
+import argparse
+import os
+
+import torch
+import numpy as np
+from mmengine.config import Config
+from mmseg.apis import init_model
+
+# Patch torch.load for PyTorch 2.6+ (weights_only=True breaks numpy in checkpoints)
+_original_torch_load = torch.load
+torch.load = lambda *args, **kwargs: _original_torch_load(*args, **{**kwargs, 'weights_only': False})
+
+try:
+    import onnx
+    import onnxruntime as rt
+except ImportError as e:
+    raise ImportError(f'Please install onnx and onnxruntime first. {e}')
+
+
+import torch.nn.functional as F
+
+# Patch adaptive_avg_pool2d for ONNX export (same approach as mmdeploy)
+_original_adaptive_avg_pool2d = F.adaptive_avg_pool2d
+
+
+def adaptive_avg_pool2d_onnx(input, output_size):
+    """ONNX-compatible adaptive_avg_pool2d rewriter (mmdeploy style).
+
+    Converts adaptive_avg_pool2d to avg_pool2d with computed kernel/stride
+    to handle cases where output_size is not a factor of input_size.
+    """
+    h_in, w_in = input.shape[2], input.shape[3]
+
+    if isinstance(output_size, int):
+        output_size = (output_size, output_size)
+    elif output_size is None:
+        output_size = (1, 1)
+
+    h_out, w_out = output_size
+
+    # Global average pooling case - use mean for clean ONNX graph
+    if h_out == 1 and w_out == 1:
+        return input.mean(dim=[2, 3], keepdim=True)
+
+    # Compute kernel_size and stride to achieve target output_size
+    stride_h = h_in // h_out
+    stride_w = w_in // w_out
+    kernel_h = h_in - (h_out - 1) * stride_h
+    kernel_w = w_in - (w_out - 1) * stride_w
+
+    return F.avg_pool2d(input, kernel_size=(kernel_h, kernel_w), stride=(stride_h, stride_w))
+
+
+# Apply the patch
+F.adaptive_avg_pool2d = adaptive_avg_pool2d_onnx
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Convert MMSegmentation models to ONNX')
+    parser.add_argument('config', help='config file path')
+    parser.add_argument('checkpoint', help='checkpoint file')
+    parser.add_argument('--show', action='store_true', help='show onnx graph')
+    parser.add_argument('--output-file', type=str, default='tmp.onnx')
+    parser.add_argument('--opset-version', type=int, default=11)
+    parser.add_argument(
+        '--verify',
+        action='store_true',
+        help='verify the onnx model output against pytorch output')
+    parser.add_argument(
+        '--shape',
+        type=int,
+        nargs='+',
+        default=[1, 3, 512, 512],
+        help='input size')
+    args = parser.parse_args()
+    return args
+
+
+def pytorch2onnx(model, input_shape, opset_version, output_file, verify, show):
+    """Export PyTorch model to ONNX format."""
+    model.eval()
+
+    # Create dummy input
+    dummy_input = torch.randn(input_shape)
+
+    # Export to ONNX
+    print(f'Exporting model to ONNX with input shape: {input_shape}')
+    torch.onnx.export(
+        model,
+        dummy_input,
+        output_file,
+        input_names=['input'],
+        output_names=['output'],
+        opset_version=opset_version,
+        dynamic_axes=None,
+        keep_initializers_as_inputs=False
+    )
+
+    print(f'Successfully exported ONNX model: {output_file}')
+
+    # Verify the exported model
+    if verify:
+        print('Verifying ONNX model...')
+        onnx_model = onnx.load(output_file)
+        onnx.checker.check_model(onnx_model)
+
+        # Compare outputs
+        with torch.no_grad():
+            pytorch_output = model(dummy_input).numpy()
+
+        sess = rt.InferenceSession(output_file)
+        onnx_output = sess.run(None, {'input': dummy_input.numpy()})[0]
+
+        if np.allclose(pytorch_output, onnx_output, rtol=1e-3, atol=1e-5):
+            print('ONNX model verified: outputs match PyTorch!')
+        else:
+            print('Warning: ONNX outputs differ from PyTorch outputs')
+            print(f'Max difference: {np.max(np.abs(pytorch_output - onnx_output))}')
+
+    if show:
+        onnx_model = onnx.load(output_file)
+        print(onnx.helper.printable_graph(onnx_model.graph))
+
+
+def export_model(config_path, checkpoint_path, output_dir=None, input_shape=(1, 3, 512, 512), opset_version=17):
+    """Export a trained MMSegmentation model to ONNX format.
+
+    Args:
+        config_path: Path to the config file or Config object
+        checkpoint_path: Path to the checkpoint file
+        output_dir: Directory to save the exported model. If None, uses config's work_dir
+        input_shape: Input shape for the model (default: (1, 3, 512, 512))
+        opset_version: ONNX opset version (default: 17)
+
+    Returns:
+        str: Path to the exported ONNX model
+    """
+    if isinstance(config_path, Config):
+        cfg = config_path
+    else:
+        cfg = Config.fromfile(config_path)
+
+    # build the model using init_model which handles registration
+    model = init_model(cfg, checkpoint_path, device='cpu')
+
+    # Replace forward with _forward for export (like mmdeploy does)
+    model.forward = model._forward
+
+    # Determine output path
+    if output_dir is None:
+        output_dir = os.path.join(cfg.work_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    model_output_path = os.path.join(output_dir, "segm_model.onnx")
+
+    pytorch2onnx(
+        model,
+        input_shape,
+        opset_version=opset_version,
+        show=False,
+        output_file=model_output_path,
+        verify=False)
+
+    print(f"Model exported successfully to: {model_output_path}")
+    return model_output_path
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    export_model(
+        args.config,
+        args.checkpoint,
+        input_shape=tuple(args.shape),
+        opset_version=args.opset_version
+    )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,19 @@
-ARG PYTORCH="1.11.0"
-ARG CUDA="11.3"
-ARG CUDNN="8"
-ARG MMCV="2.0.1"
+# It is important that cuda supports the video card architectures that are important to us:
+# NVIDIA GeForce RTX 5090               - sm_120 (Blackwell) - requires CUDA 12.8+
+# NVIDIA GeForce RTX 3060 / RTX 3060 Ti - sm_86
+# NVIDIA GeForce RTX 2080 Ti            - sm_75
+# NVIDIA A100-SXM4-40GB                 - sm_80
+# Build with a version tag
+# docker build -t quay.io/logivations/ml_all:LS_mmseg_cuda128 -f docker/Dockerfile .
+
+ARG PYTORCH="2.7.1"
+ARG CUDA="12.8"
+ARG CUDNN="9"
 
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
-ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
+ENV TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;12.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
@@ -21,24 +28,14 @@ RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 lib
 RUN conda clean --all
 
 # Install MMCV
-ARG PYTORCH
-ARG CUDA
-ARG MMCV
-RUN ["/bin/bash", "-c", "pip install openmim"]
-RUN ["/bin/bash", "-c", "mim install mmengine"]
-RUN ["/bin/bash", "-c", "mim install mmcv==${MMCV}"]
+RUN pip install openmim
+RUN mim install mmengine "mmcv>=2.0.0,<2.2.0"
 
-RUN mkdir /data
+COPY . /mmsegmentation
+WORKDIR /mmsegmentation
+
 
 # Install MMSegmentation
-RUN echo changed
-ARG MMSEGMENTATION_BRANCH
-ENV MMSEGMENTATION_BRANCH=${MMSEGMENTATION_BRANCH}
-ARG GITHUB_ACCESS_TOKEN
-RUN git clone --depth 1 -b ${MMSEGMENTATION_BRANCH} https://github.com/logivations/mmsegmentation.git /mmsegmentation
-WORKDIR /mmsegmentation
 ENV FORCE_CUDA="1"
 RUN pip install -r requirements.txt
 RUN pip install --no-cache-dir -e .
-RUN pip install git+https://github.com/facebookresearch/segment-anything.git
-RUN pip install git+https://github.com/ChaoningZhang/MobileSAM.git

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -19,4 +19,4 @@ test-tube>=0.7.5
 timm
 torch-fidelity==0.3.0
 torchmetrics==0.6.0
-transformers==4.19.2
+transformers>=4.30.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -3,3 +3,5 @@ numpy
 packaging
 prettytable
 scipy
+onnx
+onnxruntime


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column      |
| --------------------- | -------------------------------- |
| Platform tested on    | LabelStudio  |
| Ticket                |     [RTDT-6417](https://lvserv01.logivations.com/browse/RTDT-6417)              |

### Description of contribution

Reason for change:
We have no reason to use a separate mmdeploy container that requires a separate build where we copy mmpose, mmpretrain, and mmsegmantation, support, and ~25 GB of space for the image, and a bunch of unnecessary code on the ls side. Although we can export models directly where we train them.
Instead of updating cuda and checking compatibility with mmdeploy, I decided to remove this dependency and export the model automatically after training.

Results:
I compared 2 ONNX files from mmpose and mmdeploy, they have the same size, the same structure in Netron, and I get the same metrics in the end, so it works as expected.
