### PR TITLE
RTDT-7946-Fix-label-studio-segmentation-model-export

### DIFF
--- a/run_make_nvinfer.sh
+++ b/run_make_nvinfer.sh
@@ -36,10 +36,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+CLASSES_LENGTH=${#CLASSES[@]}
 CLASSES=$(IFS=';' ; echo "${CLASSES[*]}")
 RES=$(IFS=';' ; echo "${RES[*]}")
-
-CLASSES_LENGTH=${#CLASSES[@]}
 
 echo "[property]
 gpu-id=0
@@ -68,5 +67,5 @@ output-blob-names=output
 
 [custom]
 std=58.395;57.12;57.375
-detected-classes=not-empty;$CLASSES
+detected-classes=$CLASSES
 " > "$NVINFER_FILE"


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column               |
| --------------------- | ----------------------------------------- |
| Platform tested on    | Webots / Gazebo / Simple Simulation / AMR |
| Related documentation |                                           |
| Ticket                |              RTDT-7946                             |

### Description of contribution

Reason for change:
In our latest master release deepstream no longer ignores the num-detected-classes=1 config option in nvinfer-segmentation-config.txt
